### PR TITLE
Add caching of tools from tools.yaml. Update CI accordingly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,10 +66,22 @@ jobs:
           dotnet-version: 7.0.x
 
       - name: Set up Go (no caching)
+        id: setup-go
         uses: actions/setup-go@v4
         with:
           go-version: '1.20'
           cache: false
+
+      - name: Compute tools cache info
+        id: tools-cache-info
+        run: echo path=$(go env GOPATH)/bin >> $GITHUB_OUTPUT
+
+      - name: Setup tools cache
+        uses: actions/cache@v3
+        id: tools-cache
+        with:
+          path: ${{ steps.tools-cache-info.outputs.path }}
+          key: tools-go-${{ steps.setup-go.outputs.go-version }}-tools-${{ hashFiles('tools.yaml') }}
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,17 @@ jobs:
         with:
           cache-prefix: go-integration-tests
 
+      - name: Compute tools cache info
+        id: tools-cache-info
+        run: echo path=$(go env GOPATH)/bin >> $GITHUB_OUTPUT
+
+      - name: Setup tools cache
+        uses: actions/cache@v3
+        id: tools-cache
+        with:
+          path: ${{ steps.tools-cache-info.outputs.path }}
+          key: tools-go-${{ steps.setup-go.outputs.go-version }}-make-${{ hashFiles('tools.yaml') }}
+
       - name: Setup Integration Tests
         run: go run github.com/magefile/mage@v1.14.0 -v localdev minimal-pulsar
 
@@ -209,9 +220,21 @@ jobs:
 
       - name: Set up Go (no caching)
         uses: actions/setup-go@v4
+        id: setup-go
         with:
           go-version: ${{ matrix.go }}
           cache: false
+
+      - name: Compute tools cache info
+        id: tools-cache-info
+        run: echo path=$(go env GOPATH)/bin >> $GITHUB_OUTPUT
+
+      - name: Setup tools cache
+        uses: actions/cache@v3
+        id: tools-cache
+        with:
+          path: ${{ steps.tools-cache-info.outputs.path }}
+          key: tools-go-${{ steps.setup-go.outputs.go-version }}-make-${{ hashFiles('tools.yaml') }}
 
       # TODO(JayF): Consider moving this into its own job, that runs under a larger set of circumstances
       #             since it's possible for this to fail without any go changes being made.

--- a/magefiles/go.go
+++ b/magefiles/go.go
@@ -22,6 +22,10 @@ func goRun(args ...string) error {
 	return sh.Run(goBinary(), args...)
 }
 
+func goRunWith(env map[string]string, args ...string) error {
+	return sh.RunWith(env, goBinary(), args...)
+}
+
 func goVersion() (*semver.Version, error) {
 	output, err := goOutput("version")
 	if err != nil {

--- a/magefiles/main.go
+++ b/magefiles/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -14,25 +15,85 @@ import (
 
 // BootstrapTools installs all tools needed tobuild and release Armada.
 // For the list of tools this will install, see tools.yaml in the root directory
+type ToolsList struct {
+	Tools []string
+}
+
 func BootstrapTools() error {
 	mg.Deps(goCheck)
-	type ToolsList struct {
-		Tools []string
-	}
 
-	tools := &ToolsList{}
-	err := readYaml("tools.yaml", tools)
-	if err != nil {
+	requiredTools := &ToolsList{}
+	if err := readYaml("tools.yaml", requiredTools); err != nil {
 		return err
 	}
 
-	for _, tool := range tools.Tools {
-		err := goRun("install", tool)
-		if err != nil {
-			return err
+	installedToolsFilePath, err := getArmadaToolsFilePath()
+	if err != nil {
+		return err
+	}
+	installedTools := &ToolsList{}
+	if err := readYaml(installedToolsFilePath, installedTools); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	// Create a map of existing tools for quick lookup
+	installedToolsMap := make(map[string]bool)
+	for _, installedTool := range installedTools.Tools {
+		installedToolsMap[installedTool] = true
+	}
+
+	if len(requiredTools.Tools) > 0 {
+		var envPaths map[string]string
+		if isGitHubActions() {
+			envPaths = make(map[string]string)
+			for _, cache := range []string{"GOMODCACHE", "GOCACHE"} {
+				path, err := os.MkdirTemp("", cache)
+				if err != nil {
+					return fmt.Errorf("error creating temporary %s directory: %w", cache, err)
+				}
+				envPaths[cache] = path
+			}
+
+			defer func() {
+				if err := goRunWith(envPaths, "clean", "-cache", "-modcache"); err != nil {
+					fmt.Printf("Error occurred while running 'go clean': %v\n", err)
+				}
+			}()
+		}
+
+		for _, requiredTool := range requiredTools.Tools {
+			if !installedToolsMap[requiredTool] {
+				if err := goRunWith(envPaths, "install", requiredTool); err != nil {
+					return err
+				}
+				installedTools.Tools = append(installedTools.Tools, requiredTool)
+				if err := writeYAML(installedToolsFilePath, installedTools); err != nil {
+					return err
+				}
+			}
 		}
 	}
+
 	return nil
+}
+
+func isGitHubActions() bool {
+	return strings.ToLower(os.Getenv("GITHUB_ACTIONS")) == "true"
+}
+
+func getArmadaToolsFilePath() (string, error) {
+	goBinDir, err := goEnv("GOBIN")
+	if err != nil {
+		return "", err
+	}
+	if goBinDir == "" {
+		goPathDir, err := goEnv("GOPATH")
+		if err != nil {
+			return "", err
+		}
+		goBinDir = filepath.Join(goPathDir, "bin")
+	}
+	return filepath.Join(goBinDir, ".armada-tools.yaml"), nil
 }
 
 // Check dependent tools are present and the correct version.
@@ -209,6 +270,19 @@ func readYaml(filename string, out interface{}) error {
 	}
 	err = yaml.Unmarshal(bytes, out)
 	return err
+}
+
+// Helper function to write YAML data to a file
+func writeYAML(filename string, data interface{}) error {
+	bytes, err := yaml.Marshal(data)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(filename, bytes, 0o644)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // junitReport Output test results in Junit format, e.g., to display in Jenkins.


### PR DESCRIPTION
With this PR, the time to execute some jobs that need tools from tools.yaml is reduced by 2 minutes, after cache is created. However, some jobs are still long lasting (more than 9 minutes for integration tests)