### PR TITLE
Ci improvements part11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,6 @@ jobs:
           DOCKER_REPO: "gresearch"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           DOCKER_BUILDX_BUILDER: "${{ steps.buildx.outputs.name }}"
-          DOCKER_BUILDX_CACHE_FROM: "type=gha"
-          DOCKER_BUILDX_CACHE_TO: "type=gha,mode=max"
 
       - name: Output full commit sha
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,6 @@ jobs:
           DOCKER_REPO: "gresearch"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           DOCKER_BUILDX_BUILDER: "${{ steps.buildx.outputs.name }}"
-          DOCKER_BUILDX_CACHE_FROM: "type=gha"
-          DOCKER_BUILDX_CACHE_TO: "type=gha,mode=max"
   invoke-chart-push:
     name: Invoke Chart push
     needs: release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,11 +19,6 @@ env:
   # To use a builder other than "default", set this variable.
   # Necessary for, e.g., GitHub actions cache integration.
   - DOCKER_BUILDX_BUILDER={{ if index .Env "DOCKER_BUILDX_BUILDER"  }}{{ .Env.DOCKER_BUILDX_BUILDER }}{{ else }}default{{ end }}
-  # Setup to enable Docker to use, e.g., the GitHub actions cache; see
-  # https://docs.docker.com/build/building/cache/backends/
-  # https://github.com/moby/buildkit#export-cache
-  - DOCKER_BUILDX_CACHE_FROM={{ if index .Env "DOCKER_BUILDX_CACHE_FROM"  }}{{ .Env.DOCKER_BUILDX_CACHE_FROM }}{{ else }}type=inline{{ end }}
-  - DOCKER_BUILDX_CACHE_TO={{ if index .Env "DOCKER_BUILDX_CACHE_TO"  }}{{ .Env.DOCKER_BUILDX_CACHE_TO }}{{ else }}type=inline{{ end }}
   - GOVERSION={{ if index .Env "GOVERSION"  }}{{ .Env.GOVERSION }}{{ else }}go1.20{{ end }}
 
 builds:
@@ -205,8 +200,6 @@ dockers:
       - "{{ .Env.DOCKER_REPO }}armada-bundle:{{ .Version }}"
     build_flag_templates: &BUILD_FLAG_TEMPLATES
       - --builder={{ .Env.DOCKER_BUILDX_BUILDER }}
-      - --cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}
-      - --cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}
       - --label=org.opencontainers.image.source=https://github.com/armadaproject/armada
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}


### PR DESCRIPTION
After extensive testing, here are the numbers for the build/prepare job, running with and without the buildx flags:

|                                                       |                                          |                                    |
| ------------------------------- | ------------------------ | -------------------- |
|                                                        | with cache flags             | without cache flags |
| initial run, no cache in GHA         | 12m52s  :red_circle:      | 11m20s                      |
| rerun, after cache is created       | 1m56s                             | 4m52s :red_circle:   |
| after a simple code change         | 6m10s    :red_circle:      | 4m56                         |
| rerun after simple code change  | 2m15s                             | 5m14s :red_circle:    |
| after dependency change            | 12m12s       :red_circle: | 11m22s                      |
| rerun after dependency change  | 2m12s                             | 5m14s :red_circle:    |

red circles just visually guide the eye to the cell showing in which circumstances the job was slower. i know we've said that reruns don't matter that much, but i kind of feel they need to be included, because at some point, somebody will rerun a workflow for some reason, and it's not like it will happen once in several months, but more often probably. what do you think @jgiannuzzi ?

i have to execute several more tests for the release job to verify it's behaviour, and come back with numbers. what i have for now is that release job takes 7m23s in the "after code change" case, and 13m42s in "after dependency change" case, when buildx flags are removed
